### PR TITLE
Update compiler team

### DIFF
--- a/teams.toml
+++ b/teams.toml
@@ -45,17 +45,17 @@ members = [
 name = "Compiler"
 ping = "rust-lang/compiler"
 members = [
-  "arielb1",
   "cramertj",
   "eddyb",
   "estebank",
-  "jseyfried",
   "michaelwoerister",
   "nikomatsakis",
   "nrc",
   "petrochenkov",
   "pnkfelix",
   "Zoxc",
+  "nagisa",
+  "oli-obk",
 ]
 
 [T-doc]


### PR DESCRIPTION
Removed @arielb1 and @jseyfried (https://github.com/rust-lang/rust/pull/46108#issuecomment-363152084).

Added @nagisa and @oli-obk (https://internals.rust-lang.org/t/please-welcome-nagisa-and-oli-obk-to-the-compiler-team/6712).