### PR TITLE
Loosen FCP restrictions

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -908,7 +908,7 @@ impl<'a> RfcBotComment<'a> {
                     }
                 }
 
-                msg.push_str("\nOnce these reviewers reach consensus, this will enter its final ");
+                msg.push_str("\nOnce a majority of reviewers approve (and none object), this will enter its final ");
                 msg.push_str("comment period. If you spot a major issue that hasn't been raised ");
                 msg.push_str("at any point in this process, please speak up!\n");
 

--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -223,7 +223,8 @@ fn evaluate_nags() -> DashResult<()> {
             }
         };
 
-        let num_active_reviews = reviews.iter().filter(|&&(_, ref r)| !r.reviewed).count();
+        let num_outstanding_reviews = reviews.iter().filter(|&&(_, ref r)| !r.reviewed).count();
+        let num_complete_reviews = reviews.len() - num_outstanding_reviews;
         let num_active_concerns = concerns
             .iter()
             .filter(|&&(_, ref c)| c.fk_resolved_comment.is_none())
@@ -255,7 +256,9 @@ fn evaluate_nags() -> DashResult<()> {
             };
         }
 
-        if num_active_reviews == 0 && num_active_concerns == 0 {
+        let majority_complete = num_outstanding_reviews < num_complete_reviews;
+
+        if num_active_concerns == 0 && majority_complete && num_outstanding_reviews < 3 {
             // TODO only record the fcp as started if we know that we successfully commented
             // i.e. either the comment claims to have posted, or we get a comment back to reconcile
 


### PR DESCRIPTION
Allows an item to enter FCP when a majority of team members has approved
and *no* team member has objected. This retains the consensus process,
but makes it so that FCP isn't blocked *by default*. Rather, members who
object to the proposal need to register a concern to block it.