### PR TITLE
rename rustdoc team label

### DIFF
--- a/rfcbot.toml
+++ b/rfcbot.toml
@@ -122,7 +122,7 @@ members = [
   "steveklabnik",
 ]
 
-[teams.T-dev-tools-rustdoc]
+[teams.T-rustdoc]
 name = "Rustdoc"
 ping = "rust-lang/rustdoc"
 members = [


### PR DESCRIPTION
I renamed the rustdoc team label recently, to consolidate the three miscellaneous tags that were being used. This is me updating the rfcbot configuration to listen for the new tag.