### PR TITLE
Attempt at solving #217 (diesel.rs docs were misinterpreted)

### DIFF
--- a/src/domain/rfcbot.rs
+++ b/src/domain/rfcbot.rs
@@ -17,6 +17,7 @@ pub struct NewFcpProposal<'a> {
 #[derive(AsChangeset, Clone, Debug, Deserialize, Eq, Ord,
          PartialEq, PartialOrd, Queryable, Serialize)]
 #[table_name="fcp_proposal"]
+#[changeset_options(treat_none_as_null="true")]
 pub struct FcpProposal {
     pub id: i32,
     pub fk_issue: i32,


### PR DESCRIPTION
Logic defined in https://github.com/anp/rfcbot-rs/blob/master/src/github/nag.rs#L824-L828 was interpreted as setting `fcp_start` to `NULL` (in the database), but didn't change anything.

Snippet:
```rust
proposal.fcp_start = None;
let update =
    diesel::update(fcp_proposal.find(proposal.id))
          .set(&proposal)
          .execute(conn);
```

Per documentation in http://diesel.rs/guides/all-about-updates/, setting the following on `FcpProposal` should give us the behavior we wanted.
```rust
#[changeset_options(treat_none_as_null="true")]
```

At least that's the hope.