### PR TITLE
Update T-infra membership

### DIFF
--- a/rfcbot.toml
+++ b/rfcbot.toml
@@ -87,12 +87,14 @@ ping = "rust-lang/infra"
 members = [
   "aidanhs",
   "alexcrichton",
-  "aturon",
   "erickt",
   "kennytm",
   "Mark-Simulacrum",
   "shepmaster",
   "TimNN",
+  "ashleygwilliams",
+  "sgrif",
+  "pietroalbini",
 ]
 
 [teams.T-cargo]


### PR DESCRIPTION
This PR updates T-infra team membership in rfcbot, to sync it with the people listed on the website.

cc @aidanhs