### PR TITLE
Correct FCP merge text

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -1110,7 +1110,7 @@ impl<'a> RfcBotComment<'a> {
                 msg.push_str(" has proposed to ");
                 msg.push_str(disposition.repr());
                 msg.push_str(" this. The next step is review by the rest of the tagged ");
-                msg.push_str("teams:\n\n");
+                msg.push_str("team members:\n\n");
 
                 format_ticky_boxes(&mut msg,
                     reviewers.iter().map(|(m, rr)| (m, rr.reviewed)));


### PR DESCRIPTION
I wasn't sure if you could mention more than one team or not.  If it's only one team then maybe it should say:

> review by the rest of the tagged team

But going for

> review by the rest of the tagged team members

allows for it to mean all the members of all the teams.