### PR TITLE
Refer to author indirectly

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -1187,9 +1187,8 @@ impl<'a> RfcBotComment<'a> {
                 msg.push_str("), is now **complete**.");
 
                 msg.push_str("\n\nAs the automated representative of the governance process, \
-                              I would like to thank @");
-                msg.push_str(&author.login);
-                msg.push_str(" for their work and everyone else who contributed.");
+                              I would like to thank the author for their work and everyone else \
+                              who contributed.");
 
                 match disposition {
                     FcpDisposition::Merge => {


### PR DESCRIPTION
This is a quick-fix since the comment-author refers to the team member who FCPed.

See e.g. https://github.com/rust-lang/rfcs/pull/2532#issuecomment-466992905 for the bug.

We should fix this properly later, but this suffices for now and is all I have time for.

r? @anp 